### PR TITLE
url fix and title change

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -167,10 +167,10 @@ const Chat = () => {
       citation.id,
       citation.title ?? "",
       citation.filepath ?? "",
-      "",
+      citation.url ?? "",
       "",
     ]);
-    setIsCitationPanelOpen(true);
+    window.open(citation.url ?? '', '_blank')?.focus();
   };
 
   const parseCitationFromMessage = (message: ChatMessage) => {

--- a/frontend/src/pages/layout/Layout.tsx
+++ b/frontend/src/pages/layout/Layout.tsx
@@ -42,7 +42,7 @@ const Layout = () => {
                             aria-hidden="true"
                         />
                         <Link to="/" className={styles.headerTitleContainer}>
-                            <h1 className={styles.headerTitle}>Azure AI</h1>
+                            <h1 className={styles.headerTitle}>NYC MyCity Chatbot</h1>
                         </Link>
                         <div className={styles.shareButtonContainer} role="button" tabIndex={0} aria-label="Share" onClick={handleShareClick} onKeyDown={e => e.key === "Enter" || e.key === " " ? handleShareClick() : null}>
                             <ShareRegular className={styles.shareButton} />


### PR DESCRIPTION
This fixes the citations when a question is answered so the user is now taken to a url on a new tab.
Also fixes title change
![newTitle](https://github.com/Nuvalence/sample-app-aoai-chatGPT/assets/103449276/3e94c715-4b80-420c-bf63-6eee016d19b4)
![citationNewTab](https://github.com/Nuvalence/sample-app-aoai-chatGPT/assets/103449276/81eae410-ee34-41d1-9f80-f232f82c8d94)
