### PR TITLE
Fixing the missing 'a' in the error messages

### DIFF
--- a/app-original.py
+++ b/app-original.py
@@ -217,11 +217,11 @@ def stream_with_data(body, headers, endpoint):
                     logger.error("Retrying...")
                 else:
                     logger.error("Giving up and returning an error")
-                    yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+                    yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
                     return
             except requests.exceptions.RequestException as e:
                 logger.error("An error occurred:", e)
-                yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+                yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
                 return
 
         with r:
@@ -256,7 +256,7 @@ def stream_with_data(body, headers, endpoint):
             logger.info(f"stream_with_data: lines processed in {total_time} seconds")
     except Exception as e:
         logger.error(f"stream_with_data: exception processing response: {str(e)}")
-        yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+        yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
 
 
 def conversation_with_data(request):
@@ -285,11 +285,11 @@ def conversation_with_data(request):
                 logger.error("Retrying...")
             else:
                 logger.error("Giving up and returning an error")
-                yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+                yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
                 return
         except requests.exceptions.RequestException as e:
             logger.error("An error occurred:", e)
-            yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+            yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
             return
 
 

--- a/app.py
+++ b/app.py
@@ -265,7 +265,7 @@ def conversation():
                 current_index = next_index(current_index)
             else:
                 logger.error("Giving up and returning an error")
-                return Response(json.dumps({"error": "Sorry, I could not answer that. Please try asking different question."}) + "\n")
+                return Response(json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question."}) + "\n")
 
 
 if __name__ == "__main__":

--- a/pre-compute.py
+++ b/pre-compute.py
@@ -232,7 +232,7 @@ def stream_with_data(body, headers, endpoint):
             logger.info(f"stream_with_data: lines processed in {total_time} seconds")
     except Exception as e:
         logger.error(f"stream_with_data: exception processing response: {str(e)}")
-        yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+        yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
 
 
 def conversation_with_data(headers_arr, body_arr, endpoint_arr):
@@ -256,11 +256,11 @@ def conversation_with_data(headers_arr, body_arr, endpoint_arr):
                 logger.error("Retrying...")
             else:
                 logger.error("Giving up and returning an error")
-                yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+                yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
                 return
         except requests.exceptions.RequestException as e:
             logger.error("An error occurred:", e)
-            yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+            yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
             return
 
 

--- a/retry-in-stream.py
+++ b/retry-in-stream.py
@@ -222,11 +222,11 @@ def stream_with_data(request):
                     logger.error(f"stream_with_data: retrying, new index = {current_index}")
                 else:
                     logger.error("stream_with_data: giving up and returning an error")
-                    yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+                    yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
                     return
             except requests.exceptions.RequestException as e:
                 logger.error("stream_with_data: an error occurred:", e)
-                yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+                yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
                 return
 
         with r:
@@ -261,7 +261,7 @@ def stream_with_data(request):
             logger.info(f"stream_with_data: lines processed in {total_time} seconds")
     except Exception as e:
         logger.error(f"stream_with_data: exception processing response: {str(e)}")
-        yield json.dumps({"error": "Sorry, I could not answer that. Please try asking different question"}) + "\n"
+        yield json.dumps({"error": "Sorry, I could not answer that. Please try asking a different question"}) + "\n"
 
 
 def conversation_with_data(request):


### PR DESCRIPTION
I provided an error message that had a typo earlier today. This PR should clean it up. I do not have a working environment so DO NOT approve this unless you can pull it down and run it. You can test it by asking how to "kill all the rats in NYC"
